### PR TITLE
Remove of task install not avail in gradle 7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Setup Javadoc
-        run: ./gradlew install
+        run: ./gradlew clean build -x test
       - name: Prepare gpg key
         run: |
           echo "${{secrets.SIGNING_KEY_FILE}}" | base64 -d > ~/.gradle/secring.gpg


### PR DESCRIPTION
Remove ´gradle install´ task on release pipeline, which fails with gradle 7, due to ´maven´ plugin being deprecated in that version of gradle.