### PR TITLE
Feature/add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Using a customized Object Mapper you can:
 
 With Gradle
 ```gradle
-implementation 'com.github.bancolombia:data-mask-core:1.1.0'
+implementation 'com.github.bancolombia:data-mask-core:1.2.0'
 ```
 
 With maven
@@ -119,7 +119,7 @@ With maven
 <dependency>
   <groupId>com.github.bancolombia</groupId>
   <artifactId>data-mask-core</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
 </dependency>
 ```
 
@@ -166,7 +166,7 @@ as constructor arguments, the implementations of both `DataCipher` and `DataDeci
     }
 ```
 
-### C. Decorate POJO's
+### C. Decorate POJOs
 
 Members to be masked/encrypted should be annotated with `@Mask`, eg:
 
@@ -300,14 +300,18 @@ The library offers a funtionability for transform JSON without a model known. Th
 # AWS SDK integration
 
 This library offers a concrete implementation for the `DataCipher` and `DataDecipher` interfaces
-called `data-mask-aws` which provides via the **Aws crypto SDK** and Secrets Manager
-the encryption and decryption funcionality.
+called `data-mask-aws` which provides via the **Aws crypto SDK** and Secrets Manager for
+the encryption and decryption functionality.
+
+**Cloud Dependencies**:
+
+- Secrets Manager for storing the symmetric key to configure the local AWS Crypto SDK
 
 ## Using
 
 With Gradle
 ```gradle
-implementation 'com.github.bancolombia:data-mask-aws:1.1.0'
+implementation 'com.github.bancolombia:data-mask-aws:1.2.0'
 ```
 
 With maven
@@ -315,7 +319,7 @@ With maven
 <dependency>
   <groupId>com.github.bancolombia</groupId>
   <artifactId>data-mask-aws</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
 </dependency>
 ```
 
@@ -323,24 +327,27 @@ With maven
 
 Passed via configuration `application.properties` or `application.yaml`
 
-| Attribute  | Default value  | Description  |
-|---|---|---|
-| secrets.dataMaskKey  |  | Name of the stored symmetric key in AWS Secrets manager |
-| dataMask.encryptionContext | "default_context" | The context for additional protection of the encrypted data. See [Usage of Encryption contexts][encryption_context].|
-| adapters.aws.secrets-manager.region  |   | Region for the Secrets Manager service  |
-| adapters.aws.secrets-manager.endpoint  |   | (Optional) for local dev only|
+| Attribute                             | Default value     | Description                                                                                                                                                                                                                                                                                                                      |
+|---------------------------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| secrets.dataMaskKey                   |                   | Name of the secret that holds the symmetric key in AWS Secrets manager. <br> Encryption key for data-masking should be at least 16 bytes. Other lengths supported                     for AES encryption are 24 and 32 bytes. Any given key greater than 16 bytes, and not multiple of 16,  will be derived from first 16 bytes. |
+| dataMask.encryptionContext            | "default_context" | (Optional) The context for additional protection of the encrypted data. See [Usage of Encryption contexts][encryption_context].                                                                                                                                                                                                  |
+| dataMask.keyId                        | [blank]           | (Optional) The key Id                                                                                                                                                                                                                                                                                                            |
+| adapters.aws.secrets-manager.region   |                   | Region for the Secrets Manager service                                                                                                                                                                                                                                                                                           |
+| adapters.aws.secrets-manager.endpoint |                   | (Optional) for local dev only                                                                                                                                                                                                                                                                                                    |
 
 ### Use with Spring-Boot
 
 Just declare the customized Object Mapper as a Bean, and add **@Primary** annotation to use instead of the default ObjectMapper.
 
 ```java
-    @Bean
+@Bean
 @Primary
 public ObjectMapper objectMapper(DataCipher awsCipher, DataDecipher awsDecipher) {
-        return new MaskingObjectMapper(awsCipher, awsDecipher);
-        }
+    return new MaskingObjectMapper(awsCipher, awsDecipher);
+}
 ```
+
+Then is all the same as described earlier in this guide in section [C. Decorate-POJOs](#c-decorate-pojos)
 
 # Contribute
 

--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     api 'com.github.bancolombia:aws-secrets-manager-sync:4.1.0'
     api 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     implementation "software.amazon.awssdk:secretsmanager:2.20.94"
+    implementation "software.amazon.awssdk:regions:2.20.94"
     implementation 'org.springframework:spring-context'
     testImplementation 'org.springframework:spring-test'
 }

--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
     api project(":data-mask-core")
-    api 'com.github.bancolombia:aws-secrets-manager-sync:3.0.0'
-    api 'com.amazonaws:aws-encryption-sdk-java:2.3.3'
+    api 'com.github.bancolombia:aws-secrets-manager-sync:4.1.0'
+    api 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
+    implementation "software.amazon.awssdk:secretsmanager:2.20.94"
     implementation 'org.springframework:spring-context'
     testImplementation 'org.springframework:spring-test'
 }

--- a/aws/src/main/java/co/com/bancolombia/datamask/aws/AwsConfiguration.java
+++ b/aws/src/main/java/co/com/bancolombia/datamask/aws/AwsConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Profile;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Arrays;
-import java.util.UUID;
 
 @Configuration
 public class AwsConfiguration {
@@ -40,6 +39,9 @@ public class AwsConfiguration {
 
     @Value("${dataMask.encryptionContext:default_context}")
     private String encryptionContext;
+
+    @Value("${dataMask.keyId:}")
+    private String keyId;
 
     @Profile({"!local"})
     @Bean(name = "secretManagerSyncConnectorForDataMasking")
@@ -64,7 +66,7 @@ public class AwsConfiguration {
     public JceMasterKey masterKeyProvider(SecretKey retrieveEncryptionKey) {
         return JceMasterKey.getInstance(retrieveEncryptionKey,
                 this.encryptionContext,
-                UUID.randomUUID().toString(),
+                this.keyId,
                 WRAPPING_ALGORITHM);
     }
 

--- a/aws/src/main/java/co/com/bancolombia/datamask/aws/cipher/AWSEncryptionSdkDecipher.java
+++ b/aws/src/main/java/co/com/bancolombia/datamask/aws/cipher/AWSEncryptionSdkDecipher.java
@@ -2,12 +2,15 @@ package co.com.bancolombia.datamask.aws.cipher;
 
 import co.com.bancolombia.datamask.cipher.DataDecipher;
 import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.jce.JceMasterKey;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 
 import java.util.Base64;
 
 @RequiredArgsConstructor
+@Log
 public class AWSEncryptionSdkDecipher implements DataDecipher {
 
     private final AwsCrypto awsCrypto;
@@ -16,7 +19,13 @@ public class AWSEncryptionSdkDecipher implements DataDecipher {
     @Override
     public String decipher(String inputCipherData) {
         var decodedCipherData = Base64.getDecoder().decode(inputCipherData.getBytes());
-        return new String(awsCrypto.decryptData(masterKeyProvider, decodedCipherData).getResult());
+        try {
+            var cryptoResult = awsCrypto.decryptData(masterKeyProvider, decodedCipherData);
+            return new String(cryptoResult.getResult());
+        } catch (AwsCryptoException e) {
+            log.severe(e.toString());
+            return null;
+        }
     }
 
 }

--- a/aws/src/test/java/co/com/bancolombia/datamask/AwsConfigurationTests.java
+++ b/aws/src/test/java/co/com/bancolombia/datamask/AwsConfigurationTests.java
@@ -23,6 +23,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AwsConfigurationTests {
 
+    private final String TEST_REGION = "us-east-1";
+    private final String TEST_ENDPOINT = "http://some-endpoint";
+    private final String TEST_SECRET = "secret-name";
+
     private AwsConfiguration classUnderTest;
 
     @Mock
@@ -37,19 +41,17 @@ class AwsConfigurationTests {
     @BeforeEach
     void prepare() {
         classUnderTest = new AwsConfiguration();
-        ReflectionTestUtils.setField(classUnderTest, "secretWithDataMaskKey", "secret-name");
-        ReflectionTestUtils.setField(classUnderTest, "secretsRegion", "us-east-1");
-        ReflectionTestUtils.setField(classUnderTest, "secretsEndpoint", "http://some-endpoint");
+        System.setProperty("aws.region", "us-east-1");
     }
 
     @Test
     void testGetSecretsGenericManager() {
-        assertNotNull(classUnderTest.manager());
+        assertNotNull(classUnderTest.manager(TEST_REGION));
     }
 
     @Test
     void testGetLocalSecretsGenericManager() {
-        assertNotNull(classUnderTest.localManager());
+        assertNotNull(classUnderTest.localManager(TEST_REGION, TEST_ENDPOINT));
     }
 
     @Test
@@ -76,14 +78,14 @@ class AwsConfigurationTests {
     })
     void testGenerateSecretKey(String key) throws SecretException {
         when(genericManager.getSecret(anyString())).thenReturn(key);
-        assertNotNull(classUnderTest.retrieveEncryptionKey(genericManager));
+        assertNotNull(classUnderTest.retrieveEncryptionKey(genericManager, TEST_SECRET));
     }
 
     @Test
     void testFailGenerateSecretKey() throws SecretException {
         when(genericManager.getSecret(anyString())).thenReturn("1234");
         assertThrows(SecretException.class, () -> {
-            classUnderTest.retrieveEncryptionKey(genericManager);
+            classUnderTest.retrieveEncryptionKey(genericManager, TEST_SECRET);
         });
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.1.0
-springBootVersion=3.0.5
+version=1.2.0
+springBootVersion=3.1.4
 toPublish=data-mask-core,data-mask-aws
 org.gradle.daemon=true

--- a/sample/aws-example/build.gradle
+++ b/sample/aws-example/build.gradle
@@ -1,0 +1,14 @@
+dependencies {
+    implementation project(':data-mask-aws')
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.projectreactor.addons:reactor-extra'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test.onlyIf { !project.hasProperty('examplesTesting') }
+jacocoTestCoverageVerification.onlyIf { !project.hasProperty('examplesCoverage') }
+jacocoTestReport.onlyIf { !project.hasProperty('examplesCoverage') }
+
+sonarqube {
+    skipProject = true
+}

--- a/sample/aws-example/src/main/java/co/com/demo/datamask/aws/DataMaskDemoLocalApplication.java
+++ b/sample/aws-example/src/main/java/co/com/demo/datamask/aws/DataMaskDemoLocalApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class DataMaskDemoLocalApplication {
     public static void main(String[] args) {
+        System.setProperty("aws.region", "us-east-1");
         SpringApplication.run(DataMaskDemoLocalApplication.class, args);
     }
 }

--- a/sample/aws-example/src/main/java/co/com/demo/datamask/aws/DataMaskDemoLocalApplication.java
+++ b/sample/aws-example/src/main/java/co/com/demo/datamask/aws/DataMaskDemoLocalApplication.java
@@ -1,0 +1,11 @@
+package co.com.demo.datamask.aws;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DataMaskDemoLocalApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DataMaskDemoLocalApplication.class, args);
+    }
+}

--- a/sample/aws-example/src/main/java/co/com/demo/datamask/aws/config/LocalExampleConfiguration.java
+++ b/sample/aws-example/src/main/java/co/com/demo/datamask/aws/config/LocalExampleConfiguration.java
@@ -1,0 +1,36 @@
+package co.com.demo.datamask.aws.config;
+
+import co.com.bancolombia.datamask.aws.AwsConfiguration;
+import co.com.bancolombia.datamask.cipher.DataCipher;
+import co.com.bancolombia.datamask.cipher.DataDecipher;
+import co.com.bancolombia.datamask.databind.MaskingObjectMapper;
+import co.com.demo.datamask.aws.handler.DemoHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+@Import({ AwsConfiguration.class})
+public class LocalExampleConfiguration {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper(DataCipher awsCipher, DataDecipher awsDecipher) {
+        return new MaskingObjectMapper(awsCipher, awsDecipher);
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> route(DemoHandler demoHandler) {
+        return RouterFunctions
+                .route(RequestPredicates.GET("/api/creditcard"), demoHandler::queryCreditCard)
+                .andRoute(RequestPredicates.POST("/api/creditcard"), demoHandler::receiveCreditCardAgain);
+    }
+
+
+}

--- a/sample/aws-example/src/main/java/co/com/demo/datamask/aws/handler/DemoHandler.java
+++ b/sample/aws-example/src/main/java/co/com/demo/datamask/aws/handler/DemoHandler.java
@@ -1,0 +1,35 @@
+package co.com.demo.datamask.aws.handler;
+
+import co.com.demo.datamask.aws.model.CreditCard;
+import co.com.demo.datamask.aws.usecase.CreditCardsUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class DemoHandler {
+
+    private final CreditCardsUseCase useCase;
+
+    public Mono<ServerResponse> queryCreditCard(ServerRequest serverRequest) {
+        return useCase.getCreditCard()
+                .flatMap(data -> ServerResponse.ok().bodyValue(data)); // Java object encoded as JSON object. Any
+                                                                       // attribute marked for masking and/or encryption
+                                                                       // is processed.
+    }
+
+    public Mono<ServerResponse> receiveCreditCardAgain(ServerRequest serverRequest) {
+        return serverRequest.bodyToMono(CreditCard.class) // Received JSON payload is decoded again as a Java Object,
+                                                          // if any attribute was annotated for encryption, then it should
+                                                          // be decrypted back and set to the Java Object as a plain string.
+                .flatMap(useCase::receiveCreditCard)
+                .flatMap(model -> ServerResponse.ok()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue("{\"msg\": \"Data received and processed, see log to discover plain data\"}"));
+    }
+
+}

--- a/sample/aws-example/src/main/java/co/com/demo/datamask/aws/model/CreditCard.java
+++ b/sample/aws-example/src/main/java/co/com/demo/datamask/aws/model/CreditCard.java
@@ -1,0 +1,17 @@
+package co.com.demo.datamask.aws.model;
+
+import co.com.bancolombia.datamask.DataMaskingConstants;
+import co.com.bancolombia.datamask.Mask;
+import co.com.bancolombia.datamask.databind.util.TransformationType;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class CreditCard {
+    @Mask(rightVisible=4, queryOnly = TransformationType.ALL, format = DataMaskingConstants.ENCRYPTION_AS_OBJECT)
+    private String number;
+    private String clientName;
+}

--- a/sample/aws-example/src/main/java/co/com/demo/datamask/aws/usecase/CreditCardsUseCase.java
+++ b/sample/aws-example/src/main/java/co/com/demo/datamask/aws/usecase/CreditCardsUseCase.java
@@ -1,0 +1,23 @@
+package co.com.demo.datamask.aws.usecase;
+
+import co.com.demo.datamask.aws.model.CreditCard;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class CreditCardsUseCase {
+
+    public Mono<CreditCard> getCreditCard() {
+        return Mono.just(new CreditCard("1234 5678 9012 3456",
+                "John Doe"));
+    }
+
+    public Mono<CreditCard> receiveCreditCard(CreditCard creditCard) {
+        return Mono.fromSupplier(() -> {
+            System.out.println("Received data (decrypted): " + creditCard);
+            return creditCard;
+        });
+    }
+}

--- a/sample/aws-example/src/main/resources/application-local.yaml
+++ b/sample/aws-example/src/main/resources/application-local.yaml
@@ -1,0 +1,12 @@
+
+secrets:
+  dataMaskKey: demo-secret
+
+adapters:
+  aws:
+    secrets-manager:
+      region: "us-east-1"
+      endpoint: "http://localhost:4566"
+
+dataMask:
+  encryptionContext: "holamundo"

--- a/sample/aws-example/src/main/resources/application.yaml
+++ b/sample/aws-example/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+logging:
+  level:
+    web: DEBUG

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,3 +5,6 @@ project(':data-mask-core').projectDir = file('./core')
 
 include ":data-mask-aws"
 project(':data-mask-aws').projectDir = file('./aws')
+
+//include ":aws-example"
+//project(':aws-example').projectDir = file('./sample/aws-example')


### PR DESCRIPTION
- Remove ramdon keyId generation when building an instance of `com.amazonaws.encryptionsdk.jce.JceMasterKey`, which would make decrypting fail, when app is restarted.
- Remove attribute injection to configuration class `co.com.bancolombia.datamask.aws.AwsConfiguration`
- Added sample application.
- Updated documentation.