### PR TITLE
feat: enable multimasking function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,17 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
+        if: github.ref == 'refs/heads/master'
         uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID_ADMIN_GITHUB }}
           private_key: ${{ secrets.APP_PRIVATE_KEY_ADMIN_GITHUB }}
       - uses: actions/checkout@v4
+        if: github.ref == 'refs/heads/master'
         with:
           token: ${{ steps.generate_token.outputs.token }}
+      - uses: actions/checkout@v4
+        if: github.ref != 'refs/heads/master'
       - name: Verify Conventional Commits
         uses: amannn/action-semantic-pull-request@v5
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ __Anotation Properties__
 |  |  |  `false`: serialization should generate masked value and encrypted value. |
 | format | ENCRYPTION_AS_OBJECT | Describes how masked and encrypted data should be serialized. Using `ENCRYPTION_INLINE` means masked and encrypted values together are serialized as string: ```masked_pair=<masked_value>I<encrypted_value>``` |
 |  |  | Using `ENCRYPTION_AS_OBJECT`, means masked and encrypted values are serialized as a json object. |
-
+| isMultiMask  | false                | `true`: Enhanced the data masking capability to be dynamic using the separator property to identify each word separately and allowing masking each one.  Example: H**** w****<br/> `false`: The dynamic data masking is not allowed and the behavior will be as before  Example: Hello******. <br/> **optional** | 
+| separator    | " "                  | With this property you can define the divisor character to use the multimask capability <br/> **optional**                                                                                                                                                                                                       | 
 
 ### D. Use Custom ObjectMapper
 

--- a/core/src/main/java/co/com/bancolombia/datamask/Mask.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/Mask.java
@@ -14,5 +14,7 @@ public @interface Mask {
     int rightVisible() default 0;
     boolean isEmail() default false;
     TransformationType queryOnly() default TransformationType.ONLY_MASK;
+    boolean isMultiMask() default false;
+    String separator() default " ";
     String format() default DataMaskingConstants.ENCRYPTION_INLINE;
 }

--- a/core/src/main/java/co/com/bancolombia/datamask/MaskUtils.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/MaskUtils.java
@@ -15,7 +15,7 @@ public class MaskUtils {
         return MaskUtils.mask(fieldValue, 0, 0);
     }
     public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount) {
-        return MaskUtils.mask(fieldValue, 0, 0, false, null);
+        return MaskUtils.mask(fieldValue, showFirstDigitCount, showLastDigitCount, false, null);
     }
 
     public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount, boolean isMultiMask, String separator) {

--- a/core/src/main/java/co/com/bancolombia/datamask/MaskUtils.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/MaskUtils.java
@@ -12,10 +12,13 @@ public class MaskUtils {
     }
 
     public static String mask(String fieldValue) {
-        return MaskUtils.mask(fieldValue, 0,0);
+        return MaskUtils.mask(fieldValue, 0, 0);
+    }
+    public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount) {
+        return MaskUtils.mask(fieldValue, 0, 0, false, null);
     }
 
-    public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount) {
+    public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount, boolean isMultiMask, String separator) {
         if (StringUtils.isBlank(fieldValue))
             return fieldValue;
 
@@ -23,11 +26,25 @@ public class MaskUtils {
         var rightCount = cleanIntParam(showLastDigitCount);
         int length = fieldValue.length();
         int shows = leftCount + rightCount;
-        int hidden = length-shows;
-        if(shows >= length || (leftCount == 0 && rightCount == 0)){
-            return StringUtils.repeat("*",length);
+        int hidden = length - shows;
+        if (shows >= length || (leftCount == 0 && rightCount == 0)) {
+            return StringUtils.repeat("*", length);
         }
-        return StringUtils.overlay(fieldValue,StringUtils.repeat("*",hidden) ,leftCount, leftCount + hidden);
+        if (isMultiMask && fieldValue.contains(separator)) {
+            String[] parts = fieldValue.split(separator, -1);
+            StringBuilder result = new StringBuilder();
+
+            for (String part : parts) {
+                result.append(mask(part, showFirstDigitCount, showLastDigitCount,false, null));
+                result.append(separator);
+            }
+
+            result.deleteCharAt(result.length() - 1);
+            return result.toString();
+        } else {
+            return StringUtils.overlay(fieldValue, StringUtils.repeat("*", hidden), leftCount, leftCount + hidden);
+        }
+
     }
 
     public static String maskAsEmail(String fieldValue) {
@@ -55,7 +72,7 @@ public class MaskUtils {
     }
 
     public static String[] split(String input) {
-        return input.replace(DataMaskingConstants.MASKING_PREFIX,"")
+        return input.replace(DataMaskingConstants.MASKING_PREFIX, "")
                 .split("\\|");
     }
 
@@ -63,7 +80,7 @@ public class MaskUtils {
         return Optional.of(node)
                 .filter(n -> n.getNodeType().equals(JsonNodeType.OBJECT))
                 .map(n -> n.findValue(DataMaskingConstants.MASKING_ATTR) != null
-                        && n.findValue(DataMaskingConstants.ENCRYPTED_ATTR) !=null)
+                        && n.findValue(DataMaskingConstants.ENCRYPTED_ATTR) != null)
                 .orElse(false);
     }
 }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskAnnotationIntrospector.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskAnnotationIntrospector.java
@@ -22,6 +22,8 @@ public class MaskAnnotationIntrospector extends NopAnnotationIntrospector {
                         annotation.queryOnly(),
                         annotation.format(),
                         annotation.isEmail(),
+                        annotation.isMultiMask(),
+                        annotation.separator(),
                         dataCipher);
         }
         return null;

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskSerializerCommons.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskSerializerCommons.java
@@ -49,7 +49,11 @@ public class MaskSerializerCommons {
         if (TRUE.equals(maskingFormat.getIsEmail())) {
             return MaskUtils.maskAsEmail(value,maskingFormat.getLeftVisible(), maskingFormat.getRightVisible());
         } else {
-            return MaskUtils.mask(value, maskingFormat.getLeftVisible(), maskingFormat.getRightVisible());
+            return MaskUtils.mask(value,
+                    maskingFormat.getLeftVisible(),
+                    maskingFormat.getRightVisible(),
+                    maskingFormat.getIsMultiMask(),
+                    maskingFormat.getSeparator());
         }
     }
 

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskingFormat.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskingFormat.java
@@ -15,6 +15,8 @@ public class MaskingFormat {
     private int leftVisible;
     private int rightVisible;
     private Boolean isEmail = false;
+    private Boolean isMultiMask = false;
+    private String separator;
     private TransformationType transformationType = TransformationType.ONLY_MASK;
     private String format = DataMaskingConstants.ENCRYPTION_INLINE;
 
@@ -38,5 +40,14 @@ public class MaskingFormat {
         this.rightVisible = rightVisible;
         this.isEmail = isEmail;
         this.transformationType = transformationType;
+    }
+
+    public MaskingFormat(int leftVisible, int rightVisible, Boolean isEmail, Boolean isMultiMask, String separator, TransformationType transformationType) {
+        this.leftVisible = leftVisible;
+        this.rightVisible = rightVisible;
+        this.isEmail = isEmail;
+        this.isMultiMask = isMultiMask;
+        this.transformationType = transformationType;
+        this.separator = separator;
     }
 }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/StringSerializer.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/StringSerializer.java
@@ -14,18 +14,25 @@ public class StringSerializer extends StdSerializer<String> {
     private MaskingFormat maskingFormat;
     private DataCipher dataCipher;
 
-    public StringSerializer(int leftVisible, int rightVisible, TransformationType transformationType, String format, boolean isEmail, DataCipher dataCipher) {
+    public StringSerializer(int leftVisible,
+                            int rightVisible,
+                            TransformationType transformationType,
+                            String format,
+                            boolean isEmail,
+                            boolean isMultiMask,
+                            String separator,
+                            DataCipher dataCipher) {
         super(String.class);
-        maskingFormat = new MaskingFormat(leftVisible, rightVisible, isEmail, transformationType, format);
+        maskingFormat = new MaskingFormat(leftVisible, rightVisible, isEmail, isMultiMask, separator, transformationType, format);
         this.dataCipher = dataCipher;
     }
 
     @Override
     public void serialize(String value, JsonGenerator generator, SerializerProvider provider) throws IOException {
-        Object resultMask = MaskSerializerCommons.of(maskingFormat,dataCipher).applyMask(value);
-        if(resultMask instanceof String){
-            generator.writeString((String)resultMask);
-        }else {
+        Object resultMask = MaskSerializerCommons.of(maskingFormat, dataCipher).applyMask(value);
+        if (resultMask instanceof String) {
+            generator.writeString((String) resultMask);
+        } else {
             generator.writeObject(resultMask);
         }
     }

--- a/core/src/test/java/co/com/bancolombia/datamask/databind/JacksonJsonProcessorTests.java
+++ b/core/src/test/java/co/com/bancolombia/datamask/databind/JacksonJsonProcessorTests.java
@@ -110,13 +110,32 @@ class JacksonJsonProcessorTests {
 
         Company c = new Company("Acme enterprises", "9999888877776666");
         var identifyFieldCard = new IdentifyField("card", QueryType.NAME);
-        var maskFormat = Map.of(identifyFieldCard, new MaskingFormat(3, 4, false, TransformationType.ALL, DataMaskingConstants.ENCRYPTION_AS_OBJECT));
+        var maskFormat = Map.of(identifyFieldCard, new MaskingFormat(3, 4, false, false, null, TransformationType.ALL, DataMaskingConstants.ENCRYPTION_AS_OBJECT));
 
         try {
             String jsonValue = mapper.writeValueAsString(new DataMask<>(c, maskFormat));
             System.out.println(jsonValue);
             assertTrue(jsonValue.contains("\"masked\":\"999*********6666\""));
             assertTrue(jsonValue.contains("\"enc\":\"OTk5OTg4ODg3Nzc3NjY2Ng==\""));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void testMultiMaskingAsObject() {
+        setCipherMapper(new DummyCipher(), new DummyDecipher());
+
+        Company c = new Company("Acme enterprises", "9999888877776666");
+        var identifyFieldName= new IdentifyField("name", QueryType.NAME);
+        var maskFormat = Map.of(identifyFieldName, new MaskingFormat(3, 0, false, true, " ", TransformationType.ALL, DataMaskingConstants.ENCRYPTION_AS_OBJECT));
+
+        try {
+            String jsonValue = mapper.writeValueAsString(new DataMask<>(c, maskFormat));
+            System.out.println(jsonValue);
+            assertTrue(jsonValue.contains("\"masked\":\"Acm* ent********\""));
+            assertTrue(jsonValue.contains("\"enc\":\"QWNtZSBlbnRlcnByaXNlcw==\""));
         } catch (JsonProcessingException e) {
             e.printStackTrace();
             Assertions.fail();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.2.4
+version=1.3.0
 toPublish=data-mask-core,data-mask-aws
 onlyUpdater=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.3.0
+version=1.2.4
 toPublish=data-mask-core,data-mask-aws
 onlyUpdater=true


### PR DESCRIPTION
Se requiere evolucionar la capacidad de enmascaramiento de datos que hoy en día se ofrece con el objetivo de que sea dinámica.

Actualmente, solo se permite enmascarar parte del string al principio, al final o en medio, no por palabra como lo requiere el negocio.

Ejemplo de como funciona actualmente: "Seb*** ****** *****"

Ejemplo de como se espera el nuevo funcionamiento: "Seb**** Cue*** Nav***"

Se agregaron dos propiedades opcionales al enmascaramiento las cuales habilitan el enmascaramiento múltiple generando el resultado esperado, las cuales son isMultiMask y separator.
**isMultiMask** es una bandera con la que se habilita la funcionalidad 
**separator** es un string con el cual se puede definir el carácter por el cual se va a separar el campo ingresado.

Al  momento de dividir el campo a enmascarar por medio del **separator** se reutiliza la funcionalidad que existía para no afectar el comportamiento actual del código.


**Se hicieron pruebas implementando la libreria en el Distribution Router.**