### PR TITLE
fix: preserve default Jackson annotations when applying masking introspectors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Generate a token
         id: generate_token
         if: github.ref == 'refs/heads/master'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID_ADMIN_GITHUB }}
           private-key: ${{ secrets.APP_PRIVATE_KEY_ADMIN_GITHUB }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID_ADMIN_GITHUB }}
           private-key: ${{ secrets.APP_PRIVATE_KEY_ADMIN_GITHUB }}
@@ -29,7 +29,7 @@ jobs:
           issuesWoLabels: true
           stripGeneratorNotice: true
       - name: Save version
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@v2
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           push-branch: "master"

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -43,7 +43,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -51,6 +51,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@c8416b0b2bf627c349ca92fc8e3de51a64b005cf # v1.0.2
+        uses: ossf/scorecard-action@v2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -43,13 +43,14 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
+        with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+        uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
       - name: Checkout code
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@212aa9ba1e4698807023a1c11be6f9f77bef2a2c
+        uses: trufflesecurity/trufflehog@main
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID_ADMIN_GITHUB }}
           private-key: ${{ secrets.APP_PRIVATE_KEY_ADMIN_GITHUB }}

--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     api project(":data-mask-core")
     api 'com.github.bancolombia:aws-secrets-manager-sync:4.5.2'
     api 'com.amazonaws:aws-encryption-sdk-java:3.0.2'
-    implementation 'software.amazon.awssdk:secretsmanager:2.46.8'
-    implementation 'software.amazon.awssdk:regions:2.46.8'
+    implementation 'software.amazon.awssdk:secretsmanager:2.46.9'
+    implementation 'software.amazon.awssdk:regions:2.46.9'
     implementation 'org.springframework:spring-context'
     testImplementation 'org.springframework:spring-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
     id 'org.springframework.boot' version '4.1.0' apply false
     id 'org.owasp.dependencycheck' version '12.2.2' apply false
-    id 'co.com.bancolombia.cleanArchitecture' version '4.4.1'
+    id 'co.com.bancolombia.cleanArchitecture' version '4.5.0'
 }
 
 apply from: './main.gradle'

--- a/core/src/main/java/co/com/bancolombia/datamask/DataMaskingConstants.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/DataMaskingConstants.java
@@ -1,10 +1,9 @@
 package co.com.bancolombia.datamask;
 
-public class DataMaskingConstants {
+import lombok.NoArgsConstructor;
 
-    private DataMaskingConstants() {
-        //this is an utility class
-    }
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class DataMaskingConstants {
 
     public static final String MASKING_PREFIX = "masked_pair=";
     public static final String MASKING_ATTR = "masked";

--- a/core/src/main/java/co/com/bancolombia/datamask/MaskUtils.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/MaskUtils.java
@@ -1,24 +1,25 @@
 package co.com.bancolombia.datamask;
 
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.JsonNodeType;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
 
-public class MaskUtils {
-
-    private MaskUtils() {
-    }
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class MaskUtils {
 
     public static String mask(String fieldValue) {
         return MaskUtils.mask(fieldValue, 0, 0);
     }
+
     public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount) {
         return MaskUtils.mask(fieldValue, showFirstDigitCount, showLastDigitCount, false, null);
     }
 
-    public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount, boolean isMultiMask, String separator) {
+    public static String mask(String fieldValue, int showFirstDigitCount, int showLastDigitCount, boolean isMultiMask,
+                              String separator) {
         if (StringUtils.isBlank(fieldValue))
             return fieldValue;
 
@@ -35,7 +36,7 @@ public class MaskUtils {
             StringBuilder result = new StringBuilder();
 
             for (String part : parts) {
-                result.append(mask(part, showFirstDigitCount, showLastDigitCount,false, null));
+                result.append(mask(part, showFirstDigitCount, showLastDigitCount, false, null));
                 result.append(separator);
             }
 
@@ -65,10 +66,7 @@ public class MaskUtils {
     }
 
     private static int cleanIntParam(int input) {
-        if (input < 0)
-            return 0;
-        else
-            return input;
+        return Math.max(input, 0);
     }
 
     public static String[] split(String input) {

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/MaskedProperty.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/MaskedProperty.java
@@ -1,11 +1,4 @@
 package co.com.bancolombia.datamask.databind;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class MaskedProperty {
-    private final String masked;
-    private final String enc;
+public record MaskedProperty(String masked, String enc) {
 }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/MaskingObjectMapper.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/MaskingObjectMapper.java
@@ -6,6 +6,7 @@ import co.com.bancolombia.datamask.cipher.NoOpCipher;
 import co.com.bancolombia.datamask.cipher.NoOpDecipher;
 import co.com.bancolombia.datamask.databind.mask.MaskAnnotationIntrospector;
 import co.com.bancolombia.datamask.databind.unmask.UnmaskAnnotationIntrospector;
+import tools.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.Serial;
@@ -27,8 +28,11 @@ public class MaskingObjectMapper extends JsonMapper {
 
     public static JsonMapper.Builder builder(DataCipher cipher, DataDecipher decipher) {
         var introspector = pair(
-                new MaskAnnotationIntrospector(cipher),
-                new UnmaskAnnotationIntrospector(decipher)
+                pair(
+                        new MaskAnnotationIntrospector(cipher),
+                        new UnmaskAnnotationIntrospector(decipher)
+                ),
+                new JacksonAnnotationIntrospector()
         );
         return JsonMapper.builder().annotationIntrospector(introspector);
     }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/DataMask.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/DataMask.java
@@ -1,25 +1,15 @@
 package co.com.bancolombia.datamask.databind.mask;
 
-import lombok.Getter;
 import lombok.NonNull;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Getter
-public class DataMask<T> {
-    private final T data;
-    private final Map<IdentifyField, MaskingFormat> fields;
+public record DataMask<T>(T data, Map<IdentifyField, MaskingFormat> fields) {
 
-    public DataMask(T data, Map<IdentifyField, MaskingFormat> fields){
-        this.data = data;
-        this.fields = fields;
-    }
-
-    public DataMask(T data, @NonNull List<IdentifyField> defaultFields){
-        this.data = data;
-        this.fields = defaultFields.stream()
-                .collect(Collectors.toMap(k -> k, v -> new MaskingFormat()));
+    public DataMask(T data, @NonNull List<IdentifyField> defaultFields) {
+        this(data, defaultFields.stream()
+                .collect(Collectors.toMap(k -> k, v -> new MaskingFormat())));
     }
 }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/JsonSerializer.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/JsonSerializer.java
@@ -28,8 +28,8 @@ public class JsonSerializer extends StdSerializer<DataMask<?>> {
     @Override
     public void serialize(DataMask value, JsonGenerator generator, SerializationContext provider) throws JacksonException {
         JsonMapper mapper = new JsonMapper();
-        JsonNode objectNode = JsonNodePathUtils.convertValue(value.getData(), mapper);
-        Map<IdentifyField, MaskingFormat> values = value.getFields();
+        JsonNode objectNode = JsonNodePathUtils.convertValue(value.data(), mapper);
+        Map<IdentifyField, MaskingFormat> values = value.fields();
         findFields(objectNode, values);
         generator.writeTree(objectNode);
     }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskSerializerCommons.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskSerializerCommons.java
@@ -8,8 +8,6 @@ import co.com.bancolombia.datamask.databind.util.TransformationType;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
-
 import static java.lang.Boolean.TRUE;
 
 @RequiredArgsConstructor(staticName = "of")
@@ -18,7 +16,7 @@ public class MaskSerializerCommons {
     private final MaskingFormat maskingFormat;
     private final DataCipher dataCipher;
 
-    public Object applyMask(String value) throws IOException {
+    public Object applyMask(String value) {
         if (!isSuitableForMasking(value)) {
             return value;
         }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskSerializerCommons.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/MaskSerializerCommons.java
@@ -33,7 +33,7 @@ public class MaskSerializerCommons {
         return value;
     }
 
-    private Object writeWithCipher(String plainValue, String maskedValue) throws IOException {
+    private Object writeWithCipher(String plainValue, String maskedValue) {
         var cipherValue = dataCipher.cipher(plainValue);
         if(maskingFormat.getTransformationType().equals(TransformationType.ONLY_CIPHER)){
             return cipherValue;

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/mask/StringSerializer.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/mask/StringSerializer.java
@@ -8,12 +8,10 @@ import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.ser.std.StdSerializer;
 
-import java.io.IOException;
-
 public class StringSerializer extends StdSerializer<String> {
     private static final JsonMapper MAPPER = new JsonMapper();
-    private MaskingFormat maskingFormat;
-    private DataCipher dataCipher;
+    private final MaskingFormat maskingFormat;
+    private final DataCipher dataCipher;
 
     public StringSerializer(int leftVisible,
                             int rightVisible,
@@ -31,16 +29,11 @@ public class StringSerializer extends StdSerializer<String> {
 
     @Override
     public void serialize(String value, JsonGenerator generator, SerializationContext provider) throws JacksonException {
-        try {
-            Object resultMask = MaskSerializerCommons.of(maskingFormat, dataCipher).applyMask(value);
-            if (resultMask instanceof String resultMaskStr) {
-                generator.writeString(resultMaskStr);
-            } else {
-                MAPPER.writeValue(generator, resultMask);
-            }
-        } catch (IOException e) {
-            throw new JacksonException("Error during serialization", e) {
-            };
+        Object resultMask = MaskSerializerCommons.of(maskingFormat, dataCipher).applyMask(value);
+        if (resultMask instanceof String resultMaskStr) {
+            generator.writeString(resultMaskStr);
+        } else {
+            MAPPER.writeValue(generator, resultMask);
         }
     }
 }

--- a/core/src/main/java/co/com/bancolombia/datamask/databind/unmask/StringDeserializer.java
+++ b/core/src/main/java/co/com/bancolombia/datamask/databind/unmask/StringDeserializer.java
@@ -13,7 +13,6 @@ import tools.jackson.databind.node.JsonNodeType;
 import java.util.Optional;
 
 public class StringDeserializer extends StdDeserializer<String> {
-    private static final long serialVersionUID = 5586926178824899685L;
 
     private final DataDecipher dataDecipher;
 

--- a/core/src/test/java/co/com/bancolombia/datamask/databind/JacksonAnnotationProcessorTests.java
+++ b/core/src/test/java/co/com/bancolombia/datamask/databind/JacksonAnnotationProcessorTests.java
@@ -6,11 +6,13 @@ import co.com.bancolombia.datamask.cipher.DataCipher;
 import co.com.bancolombia.datamask.cipher.DataDecipher;
 import co.com.bancolombia.datamask.databind.unmask.StringDeserializer;
 import co.com.bancolombia.datamask.databind.util.TransformationType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.module.SimpleModule;
 
@@ -25,7 +27,7 @@ class JacksonAnnotationProcessorTests {
 
     @Test
     void testMaskReadOnly() {
-        ObjectMapper mapper = new MaskingObjectMapper();
+        JsonMapper mapper = new MaskingObjectMapper();
 
         Person p = new Person("Jhon Doe", "4444555566667777");
 
@@ -37,7 +39,7 @@ class JacksonAnnotationProcessorTests {
 
     @Test
     void testMaskingInlineFormat() {
-        ObjectMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
+        JsonMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
 
         Customer c = new Customer("Jhon Doe", "jhon.doe12@somedomain.com");
 
@@ -49,7 +51,7 @@ class JacksonAnnotationProcessorTests {
 
     @Test
     void testUnmaskingInlineFormat() {
-        ObjectMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
+        JsonMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
 
         String json = "{\"name\":\"Jhon Doe\",\"email\":\"masked_pair=jho******************" +
                 ".com|amhvbi5kb2UxMkBzb21lZG9tYWluLmNvbQ==\"}";
@@ -62,7 +64,7 @@ class JacksonAnnotationProcessorTests {
 
     @Test
     void testMaskingAsObject() {
-        ObjectMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
+        JsonMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
 
         Company c = new Company("Acme enterprises", "9999888877776666");
 
@@ -74,7 +76,7 @@ class JacksonAnnotationProcessorTests {
 
     @Test
     void testUnmaskingFromObject() {
-        ObjectMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
+        JsonMapper mapper = new MaskingObjectMapper(new DummyCipher(), new DummyDecipher());
 
         String json = "{\"name\":\"Acme enterprises\",\"card\":{\"masked\":\"999*********6666\"," +
                 "\"enc\":\"OTk5OTg4ODg3Nzc3NjY2Ng==\"}}";
@@ -89,7 +91,7 @@ class JacksonAnnotationProcessorTests {
     void testUnmaskingAsObjecMapperModule() {
         SimpleModule module = new SimpleModule();
         module.addDeserializer(String.class, new StringDeserializer(new DummyDecipher()));
-        ObjectMapper mapper = JsonMapper.builder().addModule(module).build();
+        JsonMapper mapper = JsonMapper.builder().addModule(module).build();
 
         String json = "{\"name\":\"Jhon Doe\",\"email\":\"masked_pair=jho******************" +
                 ".com|amhvbi5kb2UxMkBzb21lZG9tYWluLmNvbQ==\"}";
@@ -103,11 +105,40 @@ class JacksonAnnotationProcessorTests {
 
     @Test
     void testNoMasking() {
-        ObjectMapper mapper = new MaskingObjectMapper();
+        JsonMapper mapper = new MaskingObjectMapper();
         Person p = new Person("Jhon Doe", "");
         String jsonValue = mapper.writeValueAsString(p);
         System.out.println(jsonValue);
         assertFalse(jsonValue.contains("*"));
+    }
+
+    @Test
+    void testJsonIncludeNonNullIsHonored() {
+        JsonMapper mapper = new MaskingObjectMapper();
+        Account account = new Account("Jhon Doe", null, "4444555566667777");
+        String jsonValue = mapper.writeValueAsString(account);
+        System.out.println(jsonValue);
+        assertFalse(jsonValue.contains("alias"));
+        assertTrue(jsonValue.contains("************7777"));
+    }
+
+    @Test
+    void testJsonPropertyIsHonored() {
+        JsonMapper mapper = new MaskingObjectMapper();
+        Account account = new Account("Jhon Doe", "JD", "4444555566667777");
+        String jsonValue = mapper.writeValueAsString(account);
+        System.out.println(jsonValue);
+        assertTrue(jsonValue.contains("\"full_name\":\"Jhon Doe\""));
+    }
+
+    @Test
+    void testJsonIgnoreIsHonored() {
+        JsonMapper mapper = new MaskingObjectMapper();
+        Account account = new Account("Jhon Doe", "JD", "4444555566667777");
+        String jsonValue = mapper.writeValueAsString(account);
+        System.out.println(jsonValue);
+        assertFalse(jsonValue.contains("alias"));
+        assertFalse(jsonValue.contains("JD"));
     }
 
     @Data
@@ -138,6 +169,21 @@ class JacksonAnnotationProcessorTests {
 
         @Mask(leftVisible = 3, rightVisible = 4, queryOnly = TransformationType.ALL, format =
                 DataMaskingConstants.ENCRYPTION_AS_OBJECT)
+        private String card;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Account {
+        @JsonProperty("full_name")
+        private String name;
+
+        @JsonIgnore
+        private String alias;
+
+        @Mask(rightVisible = 4)
         private String card;
     }
 


### PR DESCRIPTION
Fix an issue where `MaskingObjectMapper.builder(...) `was overriding Jackson’s default AnnotationIntrospector, causing standard annotations (`@JsonInclude`, `@JsonIgnore`, `@JsonProperty`, etc.) to stop working after migrating to Jackson 3.
The fix chains the custom masking introspector with JacksonAnnotationIntrospector using `pair(...)`, ensuring both are applied.

### Tests
Added 3 tests to verify compatibility:

- `@JsonInclude(NON_NULL)`
- `@JsonProperty`
- `@JsonIgnore`

Resolve #57 